### PR TITLE
Add Resources to Learn Tech Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,4 +27,6 @@ A collection of resources and information about Orlando's technology and tech st
 ## Learn Tech
 
 * [Code School](https://www.codeschool.com/) - The interactive learning destination for aspiring and experienced developers.
+* [Pluralsight](http://www.pluralsight.com) - Code School is a Pluralsight company and its office is Pluralsight's Orlando office.
 * The Iron Yard
+* [UCF Coding Bootcamp] (http://www.ce.ucf.edu/Program/5902/Ucf-Coding-Boot-Camp/)

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ A collection of resources and information about Orlando's technology and tech st
 * [Code School](https://www.codeschool.com/) - The interactive learning destination for aspiring and experienced developers.
 * [Pluralsight](http://www.pluralsight.com) - Code School is a Pluralsight company and its office is Pluralsight's Orlando office.
 * The Iron Yard
-* [UCF Coding Bootcamp] (http://www.ce.ucf.edu/Program/5902/Ucf-Coding-Boot-Camp/)
+* [UCF Coding Bootcamp](http://www.ce.ucf.edu/Program/5902/Ucf-Coding-Boot-Camp/)


### PR DESCRIPTION
Added UCF Coding Bootcamp and Pluralsight as places to Learn Tech Section. 

The reason why I added Pluralsight to Orlando is because the Code School office is now Pluralsight's Orlando office. So, maybe it's worth for the community to be aware of it...